### PR TITLE
Refactor TodoRestControllerTests: Replace createTodo method with make…

### DIFF
--- a/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
+++ b/src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.java
@@ -51,8 +51,10 @@ public class TodoRestControllerTests {
         @DisplayName("Todo 一覧と 200 を返すこと")
         void returnsTodoListWith200() throws Exception {
             // Arrange
-            createTodo("Test Todo 1", "Description 1");
-            createTodo("Test Todo 2", "Description 2");
+            Todo todo1 = makeTestTodo("Test Todo 1", "Description 1");
+            Todo todo2 = makeTestTodo("Test Todo 2", "Description 2");
+            todoRepository.create(todo1);
+            todoRepository.create(todo2);
 
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity("/v1/todos", String.class);
@@ -71,7 +73,9 @@ public class TodoRestControllerTests {
         @DisplayName("指定された ID の Todo と 200 を返すこと")
         void returnsTodoByIdWith200() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
 
             // Act
             ResponseEntity<String> response = restTemplate.getForEntity("/v1/todos/" + todoId, String.class);
@@ -158,7 +162,8 @@ public class TodoRestControllerTests {
             // Arrange
             // 未完了 Todo を上限まで作成する
             for (int i = 0; i < 5; i++) {
-                createTodo("Todo " + i, "Description " + i);
+                Todo todo = makeTestTodo("Todo " + i, "Description " + i);
+                todoRepository.create(todo);
             }
 
             // Act
@@ -186,7 +191,8 @@ public class TodoRestControllerTests {
             // Arrange
             // 未完了 Todo を上限まで作成する
             for (int i = 0; i < 5; i++) {
-                createTodo("Todo " + i, "Description " + i);
+                Todo todo = makeTestTodo("Todo " + i, "Description " + i);
+                todoRepository.create(todo);
             }
 
             // Act
@@ -259,7 +265,9 @@ public class TodoRestControllerTests {
         @DisplayName("Todo がデータベースで完了状態に更新されること")
         void updatesTodoToFinishedInDatabase() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
 
             // Act
             restTemplate.exchange(
@@ -282,7 +290,9 @@ public class TodoRestControllerTests {
         @DisplayName("完了状態の Todo と 200 を返すこと")
         void returnsFinishedTodoWith200() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
 
             // Act
             ResponseEntity<String> response = restTemplate.exchange(
@@ -305,7 +315,9 @@ public class TodoRestControllerTests {
         @DisplayName("既に完了済みの Todo の場合は 400 を返すこと")
         void returnsBadRequestWith400ForAlreadyFinishedTodo() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
             // 一度完了させる
             restTemplate.exchange("/v1/todos/" + todoId, HttpMethod.PUT, null, String.class);
 
@@ -346,7 +358,9 @@ public class TodoRestControllerTests {
         @DisplayName("Todo がデータベースから削除されること")
         void deletesTodoFromDatabase() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
 
             // Act
             restTemplate.exchange(
@@ -364,7 +378,9 @@ public class TodoRestControllerTests {
         @DisplayName("Todo が削除された際に 204 を返すこと")
         void deletesTodoAndReturns204() throws Exception {
             // Arrange
-            String todoId = createTodo("Test Todo", "Test Description");
+            Todo todo = makeTestTodo("Test Todo", "Test Description");
+            todoRepository.create(todo);
+            String todoId = todo.getTodoId();
 
             // Act
             ResponseEntity<String> response = restTemplate.exchange(
@@ -393,17 +409,15 @@ public class TodoRestControllerTests {
     }
 
     /**
-     * テスト用 Todo を作成して ID を返す
+     * テスト用 Todo オブジェクトを生成する
      */
-    private String createTodo(String title, String description) {
+    private Todo makeTestTodo(String title, String description) {
         Todo todo = new Todo();
         todo.setTodoId(java.util.UUID.randomUUID().toString());
         todo.setTodoTitle(title);
         todo.setTodoDescription(description);
         todo.setFinished(false);
         todo.setCreatedAt(new java.util.Date());
-
-        todoRepository.create(todo);
-        return todo.getTodoId();
+        return todo;
     }
 }


### PR DESCRIPTION
This pull request refactors the test setup in `TodoRestControllerTests.java` to improve clarity and reusability. The main change involves replacing the `createTodo` method with a new `makeTestTodo` method, which now only generates a `Todo` object without persisting it. Test cases have been updated to explicitly call `todoRepository.create` for persisting the `Todo` objects.

### Refactoring of test setup:

* Replaced the `createTodo` method with `makeTestTodo`, which generates a `Todo` object without saving it to the repository. This change decouples object creation from persistence, allowing more explicit control over test setup (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL396-R421](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL396-R421)`).

### Updates to test cases:

* Updated all test cases to use `makeTestTodo` for creating `Todo` objects and added explicit calls to `todoRepository.create` for persisting them. This change ensures clarity in how test data is prepared:
  - [`returnsTodoListWith200`](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL54-R57): Updated to use `makeTestTodo` and `todoRepository.create` for creating test data (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL54-R57](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL54-R57)`).
  - [`returnsTodoByIdWith200`](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL74-R78): Refactored to use the new method and repository call for test setup (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL74-R78](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL74-R78)`).
  - [`returnsBadRequestWith400WhenUnfinishedTodoLimitReached`](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL161-R166): Adjusted the loop to use `makeTestTodo` and persist each `Todo` object (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL161-R166](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL161-R166)`).
  - [`doesNotCreateTodoWhenUnfinishedTodoLimitReached`](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL189-R195): Similar adjustment as above for test setup (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL189-R195](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL189-R195)`).
  - `updatesTodoToFinishedInDatabase` and `returnsFinishedTodoWith200`: Refactored to use `makeTestTodo` and repository persistence (`[[1]](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL262-R270)`, `[[2]](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL285-R295)`).
  - [`returnsBadRequestWith400ForAlreadyFinishedTodo`](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL308-R320): Updated to use the new method and repository persistence (`[src/todos-api/src/test/java/net/kem198/todos_api/api/todo/TodoRestControllerTests.javaL308-R320](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL308-R320)`).
  - `deletesTodoFromDatabase` and `deletesTodoAndReturns204`: Refactored to use `makeTestTodo` and `todoRepository.create` for setup (`[[1]](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL349-R363)`, `[[2]](diffhunk://#diff-f3ff1055062c368e420d9552eec39430e9717d159021a68ac3f29a76023c005fL367-R383)`).…TestTodo for improved clarity and consistency