### PR TITLE
Refactor TodoResourceMapper and TodoRestController for improved mappi…

### DIFF
--- a/src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoResourceMapper.java
+++ b/src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoResourceMapper.java
@@ -7,7 +7,8 @@ import net.kem198.todos_api.domain.model.Todo;
 @Mapper(componentModel = "spring")
 public interface TodoResourceMapper {
 
-    TodoResource map(Todo todo);
+    Todo toDomain(TodoResource todoResource);
 
-    Todo map(TodoResource todoResource);
+    TodoResource toResource(Todo todo);
+
 }

--- a/src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.java
+++ b/src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.java
@@ -25,11 +25,11 @@ import org.springframework.http.ResponseEntity;
 public class TodoRestController {
 
     private final TodoService todoService;
-    private final TodoResourceMapper beanMapper;
+    private final TodoResourceMapper todoResourceMapper;
 
-    public TodoRestController(TodoService todoService, TodoResourceMapper beanMapper) {
+    public TodoRestController(TodoService todoService, TodoResourceMapper todoResourceMapper) {
         this.todoService = todoService;
-        this.beanMapper = beanMapper;
+        this.todoResourceMapper = todoResourceMapper;
     }
 
     @GetMapping
@@ -37,29 +37,29 @@ public class TodoRestController {
         Collection<Todo> todos = todoService.findAll();
         List<TodoResource> todoResources = new ArrayList<>();
         for (Todo todo : todos) {
-            todoResources.add(beanMapper.map(todo));
+            todoResources.add(todoResourceMapper.toResource(todo));
         }
         return ResponseEntity.ok(todoResources);
     }
 
     @PostMapping
     public ResponseEntity<TodoResource> postTodos(@RequestBody @Validated TodoResource todoResource) {
-        Todo createdTodo = todoService.create(beanMapper.map(todoResource));
-        TodoResource createdTodoResponse = beanMapper.map(createdTodo);
+        Todo createdTodo = todoService.create(todoResourceMapper.toDomain(todoResource));
+        TodoResource createdTodoResponse = todoResourceMapper.toResource(createdTodo);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdTodoResponse);
     }
 
     @GetMapping("{todoId}")
     public ResponseEntity<TodoResource> getTodo(@PathVariable("todoId") String todoId) {
         Todo todo = todoService.findOne(todoId);
-        TodoResource todoResource = beanMapper.map(todo);
+        TodoResource todoResource = todoResourceMapper.toResource(todo);
         return ResponseEntity.ok(todoResource);
     }
 
     @PutMapping("{todoId}")
     public ResponseEntity<TodoResource> putTodo(@PathVariable("todoId") String todoId) {
         Todo finishedTodo = todoService.finish(todoId);
-        TodoResource finishedTodoResource = beanMapper.map(finishedTodo);
+        TodoResource finishedTodoResource = todoResourceMapper.toResource(finishedTodo);
         return ResponseEntity.ok(finishedTodoResource);
     }
 


### PR DESCRIPTION
This pull request refactors the `TodoResourceMapper` interface and updates its usage in the `TodoRestController` class to improve clarity and consistency in method naming and variable usage.

### Refactoring of `TodoResourceMapper`:
* Renamed methods for better clarity: `map(Todo)` and `map(TodoResource)` were replaced with `toResource(Todo)` and `toDomain(TodoResource)`, respectively. (`src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoResourceMapper.java`, [src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoResourceMapper.javaL10-L12](diffhunk://#diff-c4465bc2094ee71090c9e8e081ed413c0418060083a1194641280fd03bbfc1e5L10-L12))

### Updates in `TodoRestController`:
* Replaced the variable name `beanMapper` with `todoResourceMapper` for better readability and alignment with its purpose. (`src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.java`, [src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.javaL28-R62](diffhunk://#diff-771ab3baa6b719916239af590ce8d860d75bcfc0762cae180356165452403852L28-R62))
* Updated method calls to align with the new `TodoResourceMapper` method names (`toResource` and `toDomain`) across all endpoints (`GET`, `POST`, and `PUT`). (`src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.java`, [src/todos-api/src/main/java/net/kem198/todos_api/api/todo/TodoRestController.javaL28-R62](diffhunk://#diff-771ab3baa6b719916239af590ce8d860d75bcfc0762cae180356165452403852L28-R62))…ng clarity