### PR TITLE
Refactor greeting API to return plain text instead of JSON and remove…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $ java -jar build/libs/todos-api-0.0.1-SNAPSHOT.jar
 
 # Open new terminal and request to API!
 $ curl 'http://localhost:8080/v1/greeting/hello'
-{"id":1,"content":"Hello, World!"}%
+Hello, World!
 ```
 
 ## Demo APIs
@@ -154,19 +154,19 @@ $ curl 'http://localhost:8080/v1/greeting/hello'
 ```sh
 $ curl -i -X GET 'http://localhost:8080/v1/greeting/hello'
 HTTP/1.1 200
-Content-Type: application/json
-Transfer-Encoding: chunked
-Date: Mon, 28 Apr 2025 05:32:49 GMT
+Content-Type: text/plain;charset=UTF-8
+Content-Length: 14
+Date: Sat, 19 Jul 2025 17:05:36 GMT
 
-{"id":1,"content":"Hello, World!"}%
+Hello, World!
 
-$ curl -i -X GET 'http://localhost:8080/v1/greeting/hello?name=kem198'
+$ curl -i -X GET 'http://localhost:8080/v1/greeting/hello?name=KeM198'
 HTTP/1.1 200
-Content-Type: application/json
-Transfer-Encoding: chunked
-Date: Mon, 28 Apr 2025 05:33:03 GMT
+Content-Type: text/plain;charset=UTF-8
+Content-Length: 15
+Date: Sat, 19 Jul 2025 17:06:00 GMT
 
-{"id":2,"content":"Hello, kem198!"}%
+Hello, KeM198!
 ```
 
 ### `/v1/error`

--- a/src/todos-api/src/main/java/net/kem198/todos_api/api/greeting/GreetingResource.java
+++ b/src/todos-api/src/main/java/net/kem198/todos_api/api/greeting/GreetingResource.java
@@ -1,4 +1,0 @@
-package net.kem198.todos_api.api.greeting;
-
-public record GreetingResource(long id, String content) {
-}

--- a/src/todos-api/src/main/java/net/kem198/todos_api/api/greeting/GreetingRestController.java
+++ b/src/todos-api/src/main/java/net/kem198/todos_api/api/greeting/GreetingRestController.java
@@ -18,9 +18,9 @@ public class GreetingRestController {
     }
 
     @GetMapping("/hello")
-    public GreetingResource getContent(@RequestParam(value = "name", defaultValue = "World") String name) {
-        GreetingResource greetingResource = greetingService.processGreeting(name);
+    public String getContent(@RequestParam(value = "name", defaultValue = "World") String name) {
+        String greetingText = greetingService.execute(name);
 
-        return greetingResource;
+        return greetingText;
     }
 }

--- a/src/todos-api/src/main/java/net/kem198/todos_api/domain/service/greeting/GreetingService.java
+++ b/src/todos-api/src/main/java/net/kem198/todos_api/domain/service/greeting/GreetingService.java
@@ -1,20 +1,13 @@
 package net.kem198.todos_api.domain.service.greeting;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.springframework.stereotype.Service;
-
-import net.kem198.todos_api.api.greeting.GreetingResource;
 
 @Service
 public class GreetingService {
 
-    private static final String template = "Hello, %s!";
-    private final AtomicLong counter = new AtomicLong();
+    private static final String template = "Hello, %s!\n";
 
-    public GreetingResource processGreeting(String name) {
-
-        GreetingResource greetingDto = new GreetingResource(counter.incrementAndGet(), String.format(template, name));
-        return greetingDto;
+    public String execute(String name) {
+        return String.format(template, name);
     }
 }

--- a/src/todos-api/src/test/java/net/kem198/todos_api/api/greeting/GreetingRestControllerTests.java
+++ b/src/todos-api/src/test/java/net/kem198/todos_api/api/greeting/GreetingRestControllerTests.java
@@ -7,10 +7,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import org.springframework.boot.test.web.client.TestRestTemplate;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class GreetingRestControllerTests {
@@ -24,24 +23,25 @@ public class GreetingRestControllerTests {
         @DisplayName("デフォルトの名前で挨拶を返す")
         void returnsGreetingWithDefaultName() {
             // Act
-            ResponseEntity<GreetingResource> response = restTemplate.getForEntity("/v1/greeting/hello",
-                    GreetingResource.class);
+            ResponseEntity<String> response = restTemplate.getForEntity("/v1/greeting/hello",
+                    String.class);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
-            assertEquals("Hello, World!", response.getBody().content());
+            assertEquals("Hello, World!\n", response.getBody());
         }
 
         @Test
         @DisplayName("指定された名前で挨拶を返す")
         void returnsGreetingWithSpecifiedName() {
             // Act
-            ResponseEntity<GreetingResource> response = restTemplate.getForEntity("/v1/greeting/hello?name=KeM198",
-                    GreetingResource.class);
+            ResponseEntity<String> response = restTemplate.getForEntity("/v1/greeting/hello?name=KeM198",
+                    String.class);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
-            assertEquals("Hello, KeM198!", response.getBody().content());
+            assertEquals("Hello, KeM198!\n" + //
+                    "", response.getBody());
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the `todos-api` application to simplify the greeting functionality by removing the `GreetingResource` class and switching to plain string responses. The changes affect the API response format, service implementation, controller logic, and corresponding tests.

### API and Response Format Changes:
* Updated the API to return plain text responses instead of JSON, with changes to the `Content-Type` and response body format in the `README.md` examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R147) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R169)

### Code Simplification:
* Removed the `GreetingResource` class, as it is no longer needed for the simplified response structure.
* Modified the `GreetingService` to return a formatted string directly, replacing the previous logic that created a `GreetingResource` object.
* Updated the `GreetingRestController` to return plain strings instead of `GreetingResource` objects, aligning with the new service logic.

### Test Adjustments:
* Refactored the `GreetingRestControllerTests` to test plain string responses instead of `GreetingResource` objects, ensuring compatibility with the updated API behavior.… GreetingResource class