### PR TITLE
Remove spring-boot-web from todos-core and refactor responsibilities

### DIFF
--- a/src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandler.java
+++ b/src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import net.kem198.todos.core.exception.common.BusinessException;
+import net.kem198.todos.core.exception.common.ResourceNotFoundException;
 
 @ControllerAdvice
 public class RestGlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -42,8 +43,17 @@ public class RestGlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ProblemDetail> handleBusinessException(BusinessException ex) {
-        return ResponseEntity
-                .status(ex.getProblemDetail().getStatus())
-                .body(ex.getProblemDetail());
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setDetail(ex.getMessage());
+        problemDetail.setProperty("errorCode", ex.getErrorCode());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleResourceNotFound(ResourceNotFoundException ex) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        problemDetail.setDetail(ex.getMessage());
+        problemDetail.setProperty("errorCode", ex.getErrorCode());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
     }
 }

--- a/src/backend/modules/todos-core/build.gradle
+++ b/src/backend/modules/todos-core/build.gradle
@@ -23,7 +23,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot'
     implementation 'org.springframework:spring-tx'
-    implementation 'org.springframework:spring-web'
     testImplementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation project(':todos-infrastructure')

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/BusinessException.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/BusinessException.java
@@ -1,18 +1,14 @@
 package net.kem198.todos.core.exception.common;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ProblemDetail;
-
 public abstract class BusinessException extends RuntimeException {
-    private final ProblemDetail problemDetail;
+    private final ErrorCode errorCode;
 
-    protected BusinessException(HttpStatus status, String detail) {
-        super(detail);
-        this.problemDetail = ProblemDetail.forStatus(status);
-        this.problemDetail.setDetail(detail);
+    protected BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
     }
 
-    public ProblemDetail getProblemDetail() {
-        return problemDetail;
+    public String getErrorCode() {
+        return errorCode.getCode();
     }
 }

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ErrorCode.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ErrorCode.java
@@ -1,0 +1,16 @@
+package net.kem198.todos.core.exception.common;
+
+public enum ErrorCode {
+    RESOURCE_NOT_FOUND("E404"),
+    BUSINESS_ERROR("E400");
+
+    private final String code;
+
+    ErrorCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ResourceNotFoundException.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ResourceNotFoundException.java
@@ -1,9 +1,11 @@
 package net.kem198.todos.core.exception.common;
 
-import org.springframework.http.HttpStatus;
-
 public class ResourceNotFoundException extends BusinessException {
-    public ResourceNotFoundException(String resourceName, Object resourceId) {
-        super(HttpStatus.NOT_FOUND, "[E002] [" + resourceName + "] Resource is not found: " + resourceId);
+    public ResourceNotFoundException(String resourceName) {
+        super(ErrorCode.RESOURCE_NOT_FOUND, String.format("Resource is not found: %s", resourceName));
+    }
+
+    public ResourceNotFoundException(String resourceKey, Object resourceValue) {
+        super(ErrorCode.RESOURCE_NOT_FOUND, String.format("Resource is not found: %s: %s", resourceKey, resourceValue));
     }
 }

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/todo/AlreadyFinishedTodoException.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/todo/AlreadyFinishedTodoException.java
@@ -1,12 +1,10 @@
 package net.kem198.todos.core.exception.todo;
 
-import org.springframework.http.HttpStatus;
-
 import net.kem198.todos.core.exception.common.BusinessException;
+import net.kem198.todos.core.exception.common.ErrorCode;
 
 public class AlreadyFinishedTodoException extends BusinessException {
-    public AlreadyFinishedTodoException(String resourceName) {
-        super(HttpStatus.BAD_REQUEST,
-                "[E003] [" + resourceName + "] The Todo is already finished.");
+    public AlreadyFinishedTodoException() {
+        super(ErrorCode.BUSINESS_ERROR, "The Todo is already finished.");
     }
 }

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/todo/MaxUnfinishedTodoException.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/todo/MaxUnfinishedTodoException.java
@@ -1,12 +1,11 @@
 package net.kem198.todos.core.exception.todo;
 
-import org.springframework.http.HttpStatus;
-
 import net.kem198.todos.core.exception.common.BusinessException;
+import net.kem198.todos.core.exception.common.ErrorCode;
 
 public class MaxUnfinishedTodoException extends BusinessException {
-    public MaxUnfinishedTodoException(String resourceName, long maxCount) {
-        super(HttpStatus.BAD_REQUEST,
-                "[E001] [" + resourceName + "] The count of un-finished Todo must not be over: " + maxCount);
+    public MaxUnfinishedTodoException(long maxCount) {
+        super(ErrorCode.BUSINESS_ERROR,
+                String.format("The count of un-finished Todo must not be over: %d", maxCount));
     }
 }

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.java
@@ -29,7 +29,7 @@ public class TodoServiceImpl implements TodoService {
     public Todo findOne(String todoId) {
         Todo todo = todoRepository.findById(todoId);
         if (todo == null) {
-            throw new ResourceNotFoundException(this.getClass().getName(), todoId);
+            throw new ResourceNotFoundException("todoId", todoId);
         }
         return todo;
     }
@@ -44,7 +44,7 @@ public class TodoServiceImpl implements TodoService {
     public Todo create(Todo todo) {
         long unfinishedCount = todoRepository.countByFinished(false);
         if (unfinishedCount >= MAX_UNFINISHED_COUNT) {
-            throw new MaxUnfinishedTodoException(this.getClass().getName(), MAX_UNFINISHED_COUNT);
+            throw new MaxUnfinishedTodoException(MAX_UNFINISHED_COUNT);
         }
 
         String todoId = UUID.randomUUID().toString();
@@ -63,7 +63,7 @@ public class TodoServiceImpl implements TodoService {
     public Todo finish(String todoId) {
         Todo todo = findOne(todoId);
         if (todo.isFinished()) {
-            throw new AlreadyFinishedTodoException(this.getClass().getName());
+            throw new AlreadyFinishedTodoException();
         }
         todo.setFinished(true);
         todoRepository.update(todo);


### PR DESCRIPTION
This pull request introduces a significant refactor to the exception handling mechanism in the `todos-core` and `todos-api` modules. The changes replace direct usage of `HttpStatus` and `ProblemDetail` with a custom `ErrorCode` enumeration to improve consistency and clarity in error reporting. Additionally, new exception handling methods are added to the `RestGlobalExceptionHandler` class, and several exception classes are refactored for better maintainability.

### Refactor of exception handling:

* **Introduction of `ErrorCode` enumeration**: Added the `ErrorCode` enum to centralize error codes and their string representations (`RESOURCE_NOT_FOUND`, `BUSINESS_ERROR`). This replaces the previous approach of embedding error codes directly in exception messages. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ErrorCode.javaR1-R16](diffhunk://#diff-4f35b46269351c96b6f45b0ff7963d1d810d5dc51dbbccf636b2e55dd80755afR1-R16)`)
* **Refactoring of `BusinessException`**: Updated `BusinessException` to use `ErrorCode` instead of `ProblemDetail`, simplifying the exception structure and removing dependency on `HttpStatus`. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/BusinessException.javaL3-R12](diffhunk://#diff-1f351f331d43d2fa28ab3e8e0268bc69d5980baae91151484d60a055bba2dd54L3-R12)`)
* **Refactoring specific exception classes**:
  - [`ResourceNotFoundException`](diffhunk://#diff-8cceca2da3004902ef275fbf7c995ab44fd3a84de8c5a7b4d326f61852876342L3-R9): Updated constructors to use `ErrorCode.RESOURCE_NOT_FOUND` and improved message formatting. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/exception/common/ResourceNotFoundException.javaL3-R9](diffhunk://#diff-8cceca2da3004902ef275fbf7c995ab44fd3a84de8c5a7b4d326f61852876342L3-R9)`)
  - `AlreadyFinishedTodoException` and `MaxUnfinishedTodoException`: Updated constructors to use `ErrorCode.BUSINESS_ERROR` and simplified message formatting. (`[[1]](diffhunk://#diff-75a63ac38383bf9bf9d97a99e803cdcacc6954fe18e0b0a088609571f721fdd3L3-R8)`, `[[2]](diffhunk://#diff-c2f6f64477c83807a9d9af38963d0ad0c66b2c96e3261108c61df3111af293d4L3-R9)`)

### Updates to `RestGlobalExceptionHandler`:

* **Enhanced exception handling methods**: Added a new handler for `ResourceNotFoundException` and refactored the existing handler for `BusinessException` to construct `ProblemDetail` objects manually, including error codes and detailed messages. (`[src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandler.javaL45-R57](diffhunk://#diff-34af2593e774c597d4f463a125e79a3cd75118e4657564b2a6463f981ebd9eefL45-R57)`)
* **Dependency update**: Imported `ResourceNotFoundException` for handling in the global exception handler. (`[src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/error/RestGlobalExceptionHandler.javaR18](diffhunk://#diff-34af2593e774c597d4f463a125e79a3cd75118e4657564b2a6463f981ebd9eefR18)`)

### Updates to service implementation:

* **Improved exception throwing in `TodoServiceImpl`**:
  - [`findOne`](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL32-R32): Refactored to use the updated `ResourceNotFoundException` constructor. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.javaL32-R32](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL32-R32)`)
  - [`create`](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL47-R47): Refactored to use the updated `MaxUnfinishedTodoException` constructor. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.javaL47-R47](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL47-R47)`)
  - [`finish`](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL66-R66): Refactored to use the updated `AlreadyFinishedTodoException` constructor. (`[src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.javaL66-R66](diffhunk://#diff-654cdc96c81b345761f7527e1317a756ede92686b91a5efa581ee350b9047abbL66-R66)`)

### Dependency cleanup:

* **Removed unused dependency**: `spring-web` dependency was removed from the `todos-core` module's `build.gradle` file as it is no longer required. (`[src/backend/modules/todos-core/build.gradleL26](diffhunk://#diff-00d8386b8198913f9826171560284042ecf563733a721882b98a3dd450999944L26)`)