### PR TITLE
feat: add CORS configuration and corresponding tests for API

### DIFF
--- a/src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/config/WebMvcConfig.java
+++ b/src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package net.kem198.todos.api.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(@NonNull CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/config/WebMvcConfigTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/config/WebMvcConfigTests.java
@@ -67,7 +67,7 @@ public class WebMvcConfigTests {
             result.andExpect(status().isOk())
                     .andExpect(header().string("Access-Control-Allow-Origin", allowedOrigin))
                     .andExpect(header().string("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS"))
-                    .andExpect(header().string("Access-Control-Allow-Headers", requestHeaders)) // 実際のヘッダー値
+                    .andExpect(header().string("Access-Control-Allow-Headers", requestHeaders))
                     .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
         }
 

--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/config/WebMvcConfigTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/config/WebMvcConfigTests.java
@@ -1,0 +1,75 @@
+package net.kem198.todos.api.common.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+public class WebMvcConfigTests {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+    }
+
+    @Nested
+    @DisplayName("CORS 設定のテスト")
+    class AddCorsMappingsTests {
+
+        @Test
+        @DisplayName("許可されたオリジンからのリクエストに対して CORS ヘッダが設定されること")
+        void shouldSetCorsHeadersForAllowedOrigin() throws Exception {
+            // Arrange
+            String allowedOrigin = "http://localhost:3000";
+
+            // Act
+            ResultActions result = mockMvc.perform(get("/v1/greeting/hello")
+                    .header("Origin", allowedOrigin));
+
+            // Assert
+            result.andExpect(status().isOk())
+                    .andExpect(header().string("Access-Control-Allow-Origin", allowedOrigin))
+                    .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+        }
+
+        @Test
+        @DisplayName("プリフライトリクエストに対して適切な CORS ヘッダが設定されること")
+        void shouldHandlePreflightRequestWithCorsHeaders() throws Exception {
+            // Arrange
+            String allowedOrigin = "http://localhost:3000";
+            String requestMethod = "GET";
+            String requestHeaders = "Content-Type";
+
+            // Act
+            ResultActions result = mockMvc.perform(options("/v1/greeting/hello")
+                    .header("Origin", allowedOrigin)
+                    .header("Access-Control-Request-Method", requestMethod)
+                    .header("Access-Control-Request-Headers", requestHeaders));
+
+            // Assert
+            result.andExpect(status().isOk())
+                    .andExpect(header().string("Access-Control-Allow-Origin", allowedOrigin))
+                    .andExpect(header().string("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS"))
+                    .andExpect(header().string("Access-Control-Allow-Headers", requestHeaders)) // 実際のヘッダー値
+                    .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+        }
+
+    }
+}


### PR DESCRIPTION
This pull request introduces CORS (Cross-Origin Resource Sharing) support to the backend by adding a new configuration class and corresponding integration tests. The main goal is to allow requests from `http://localhost:3000` (likely the frontend) and ensure proper CORS headers are set for both normal and preflight requests.

### Backend configuration

* Added `WebMvcConfig` class to configure CORS, allowing requests from `http://localhost:3000` with specified HTTP methods, headers, and credentials. (`src/backend/modules/todos-api/src/main/java/net/kem198/todos/api/common/config/WebMvcConfig.java`)

### Testing

* Added `WebMvcConfigTests` to verify that CORS headers are correctly set for allowed origins and preflight requests, ensuring the configuration works as expected. (`src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/common/config/WebMvcConfigTests.java`)