### PR TITLE
Feature/mod

### DIFF
--- a/src/frontend/todos-web/.prettierrc
+++ b/src/frontend/todos-web/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["prettier-plugin-organize-imports"]
+  "plugins": ["prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"]
 }

--- a/src/frontend/todos-web/package-lock.json
+++ b/src/frontend/todos-web/package-lock.json
@@ -25,11 +25,12 @@
         "eslint-config-next": "15.5.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-unicorn": "^61.0.2",
-        "happy-dom": "^15.7.4",
+        "happy-dom": "^20.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
         "prettier": "^3.6.2",
         "prettier-plugin-organize-imports": "^4.3.0",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vite-tsconfig-paths": "^5.1.4",
@@ -2254,6 +2255,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.45.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
@@ -3872,19 +3880,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -5073,18 +5068,18 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "15.11.7",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
-      "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.0.tgz",
+      "integrity": "sha512-GkWnwIFxVGCf2raNrxImLo397RdGhLapj5cT3R2PT7FwL62Ze1DROhzmYW7+J3p9105DYMVenEejEbnq5wA37w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0",
-        "webidl-conversions": "^7.0.0",
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
         "whatwg-mimetype": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -6870,6 +6865,93 @@
         }
       }
     },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -8505,16 +8587,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/src/frontend/todos-web/package.json
+++ b/src/frontend/todos-web/package.json
@@ -35,6 +35,7 @@
     "lint-staged": "^16.2.3",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.3.0",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",

--- a/src/frontend/todos-web/package.json
+++ b/src/frontend/todos-web/package.json
@@ -30,7 +30,7 @@
     "eslint-config-next": "15.5.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-unicorn": "^61.0.2",
-    "happy-dom": "^15.7.4",
+    "happy-dom": "^20.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",
     "prettier": "^3.6.2",


### PR DESCRIPTION
This pull request updates frontend tooling and dependencies for the `todos-web` project, focusing on improving code formatting and keeping test utilities up to date. The most significant changes are the addition of the `prettier-plugin-tailwindcss` for better Tailwind CSS class sorting, and upgrading the `happy-dom` library for testing. Several dependency updates and removals are also included to support these changes.

**Formatting and Tooling Enhancements:**

* Added `prettier-plugin-tailwindcss` to both `package.json` and `.prettierrc`, enabling automatic sorting of Tailwind CSS classes in code formatting. [[1]](diffhunk://#diff-a0fe9cf813effbf06682c715c24bfe1d452b5b9ed6a39101fcc3bc04815448c1L33-R38) [[2]](diffhunk://#diff-2306bc7eead741690e1f568b6f2da61ad405c36a6ec70f90a3b4314a67f70bdfL2-R2)
* Updated `package-lock.json` to include `prettier-plugin-tailwindcss` and its peer dependencies. [[1]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54L28-R33) [[2]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54R6868-R6954)

**Testing Library Updates:**

* Upgraded `happy-dom` from version `15.7.4` to `20.0.0` in both `package.json` and `package-lock.json`, ensuring compatibility with newer Node.js versions and improving test reliability. [[1]](diffhunk://#diff-a0fe9cf813effbf06682c715c24bfe1d452b5b9ed6a39101fcc3bc04815448c1L33-R38) [[2]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54L28-R33) [[3]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54L5076-R5082)

**Dependency Management:**

* Removed unused dependencies (`entities`, `webidl-conversions`) from `package-lock.json` as part of the `happy-dom` upgrade, and added new dev dependencies (`@types/whatwg-mimetype`) required by the updated libraries. [[1]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54R2258-R2264) [[2]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54L3875-L3887) [[3]](diffhunk://#diff-8195049f00957d805bd2cc3b71160db53c27f0011159ed7952ebe487b079ba54L8510-L8519)