### PR TITLE
Feature/mod todos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,46 @@ services:
     ports:
       - 5432:5432
     environment:
-      - LANG
-      - TZ
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
-      - POSTGRES_DB
+      LANG: "${LANG:-ja_JP.UTF-8}"
+      TZ: "${TZ:-Asia/Tokyo}"
+      POSTGRES_USER: "${POSTGRES_USER:-postgres}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
+      POSTGRES_DB: "${POSTGRES_DB:-todos_db}"
     volumes:
       - ./postgres/init:/docker-entrypoint-initdb.d
-      - db-volume:/var/lib/postgresql/dataS
+      - db-volume:/var/lib/postgresql/data
     logging:
       driver: "json-file"
       options:
         max-size: "1m"
         max-file: "2"
-    restart: always
+    restart: on-failure
+
+  api:
+    image: gradle:9.1.0-jdk21
+    working_dir: /workspace/src/backend
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-todos_db}"
+      SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-postgres}"
+      SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
+      LANG: "${LANG:-ja_JP.UTF-8}"
+      TZ: "${TZ:-Asia/Tokyo}"
+      GRADLE_USER_HOME: "/home/gradle/.gradle"
+    volumes:
+      - ./src/backend:/workspace/src/backend:cached
+      - api-gradle-cache:/home/gradle/.gradle
+    depends_on:
+      - db
+    command: sh -c "./gradlew bootRun --no-daemon"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "2"
+    restart: on-failure
 
 volumes:
   db-volume:
+  api-gradle-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,30 +19,30 @@ services:
         max-file: "2"
     restart: on-failure
 
-  api:
-    image: gradle:9.1.0-jdk21
-    working_dir: /workspace/src/backend
-    ports:
-      - "8080:8080"
-    environment:
-      SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-todos_db}"
-      SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-postgres}"
-      SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
-      LANG: "${LANG:-ja_JP.UTF-8}"
-      TZ: "${TZ:-Asia/Tokyo}"
-      GRADLE_USER_HOME: "/home/gradle/.gradle"
-    volumes:
-      - ./src/backend:/workspace/src/backend:cached
-      - api-gradle-cache:/home/gradle/.gradle
-    depends_on:
-      - db
-    command: sh -c "./gradlew bootRun --no-daemon"
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "1m"
-        max-file: "2"
-    restart: on-failure
+  # api:
+  #   image: gradle:9.1.0-jdk21
+  #   working_dir: /workspace/src/backend
+  #   ports:
+  #     - "8080:8080"
+  #   environment:
+  #     SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/${POSTGRES_DB:-todos_db}"
+  #     SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-postgres}"
+  #     SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-postgres}"
+  #     LANG: "${LANG:-ja_JP.UTF-8}"
+  #     TZ: "${TZ:-Asia/Tokyo}"
+  #     GRADLE_USER_HOME: "/home/gradle/.gradle"
+  #   volumes:
+  #     - ./src/backend:/workspace/src/backend:cached
+  #     - api-gradle-cache:/home/gradle/.gradle
+  #   depends_on:
+  #     - db
+  #   command: sh -c "./gradlew bootRun --no-daemon"
+  #   logging:
+  #     driver: "json-file"
+  #     options:
+  #       max-size: "1m"
+  #       max-file: "2"
+  #   restart: on-failure
 
 volumes:
   db-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,4 @@ services:
 
 volumes:
   db-volume:
-  api-gradle-cache:
+  # api-gradle-cache:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration, primarily improving how environment variables are set for the `db` service and fixing a volume path typo. It also comments out a previously defined `api` service for potential future use.

**Improvements to environment variable handling and configuration:**

* Changed the `db` service's environment variables from a list to explicit key-value pairs with sensible default values, making the configuration more robust and easier to understand.
* Fixed a typo in the volume path for the `db` service (`dataS` → `data`), ensuring proper data persistence.
* Changed the `restart` policy for the `db` service from `always` to `on-failure`, which is generally safer in development environments.

**Commented-out service configuration:**

* Added a commented-out `api` service configuration, including environment variables, volumes, and logging options, which can be enabled for backend development as needed.
* Added a new `api-gradle-cache` volume for use with the `api` service, currently commented out.