### PR TITLE
Reapply "fix: update Todo creation logic to correctly set finished st…

### DIFF
--- a/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/todo/TodoRestControllerTests.java
+++ b/src/backend/modules/todos-api/src/test/java/net/kem198/todos/api/todo/TodoRestControllerTests.java
@@ -131,6 +131,54 @@ public class TodoRestControllerTests {
         }
 
         @Test
+        @DisplayName("Todo の finished が true で渡された場合、データベースに true で保存されること")
+        void shouldSaveTodoFinishedWhenPassedFinished() throws Exception {
+            // Act
+            String requestBody = """
+                        {
+                            "todoTitle": "Hello World!",
+                            "todoDescription": "Hello Todo Description!",
+                            "finished": true
+                        }
+                    """;
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> requestEntity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity("/v1/todos", requestEntity, String.class);
+
+            // Assert
+            JsonNode responseBody = objectMapper.readTree(response.getBody());
+            String createdTodoId = responseBody.get("todoId").asText();
+            Todo savedTodo = todoRepository.findById(createdTodoId);
+            assertNotNull(savedTodo);
+            assertTrue(savedTodo.isFinished());
+        }
+
+        @Test
+        @DisplayName("Todo の finished が false で渡された場合、データベースに false で保存されること")
+        void shouldSaveTodoUnfinishedWhenPassedUnfinished() throws Exception {
+            // Act
+            String requestBody = """
+                        {
+                            "todoTitle": "Hello World!",
+                            "todoDescription": "Hello Todo Description!",
+                            "finished": false
+                        }
+                    """;
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<String> requestEntity = new HttpEntity<>(requestBody, headers);
+            ResponseEntity<String> response = restTemplate.postForEntity("/v1/todos", requestEntity, String.class);
+
+            // Assert
+            JsonNode responseBody = objectMapper.readTree(response.getBody());
+            String createdTodoId = responseBody.get("todoId").asText();
+            Todo savedTodo = todoRepository.findById(createdTodoId);
+            assertNotNull(savedTodo);
+            assertFalse(savedTodo.isFinished());
+        }
+
+        @Test
         @DisplayName("作成された Todo と 201 を返すこと")
         void shouldReturnCreatedTodoWith201() throws Exception {
             // Act

--- a/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.java
+++ b/src/backend/modules/todos-core/src/main/java/net/kem198/todos/core/service/todo/TodoServiceImpl.java
@@ -52,7 +52,7 @@ public class TodoServiceImpl implements TodoService {
 
         todo.setTodoId(todoId);
         todo.setCreatedAt(createdAt);
-        todo.setFinished(false);
+        todo.setFinished(Boolean.TRUE.equals(todo.isFinished()));
 
         todoRepository.create(todo);
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across both the backend and frontend of the Todos application, focusing on better handling of the `finished` state for todos, enhanced test coverage, improved frontend sorting logic, and some UI/UX refinements.

**Backend improvements:**

* Added two new integration tests in `TodoRestControllerTests.java` to verify that the `finished` property is correctly saved as `true` or `false` in the database when provided in the request payload.
* Updated `TodoServiceImpl.java` to set the `finished` property based on the incoming value, defaulting to `false` only if not explicitly set, ensuring accurate persistence of the todo's completion state.

**Frontend improvements:**

* Enhanced the sorting logic in `getTodos` so that unfinished todos are listed before finished ones, and within each group, todos are sorted by creation date in descending order.

**Testing and cleanup:**

* Improved Playwright E2E tests by adding cleanup logic to remove test data after execution, ensuring a clean state for subsequent runs.
* Minor refactor to move the `apiBaseUrl` constant to the top of the test file for clarity.

**UI/UX and code quality:**

* Updated `TodoItem` and `TodoToggle` components to improve accessibility and flexibility, such as passing through additional props and removing unnecessary anchor tags. [[1]](diffhunk://#diff-e47634d6dd516119f77db4e25011ba61444acbf52e799abf75985d7f90ad92a7L29-R35) [[2]](diffhunk://#diff-e47634d6dd516119f77db4e25011ba61444acbf52e799abf75985d7f90ad92a7L64) [[3]](diffhunk://#diff-8cd1128d2d44a2057c5514d3dd7ab2c13ad2a2ed101df23f99868de5a4f2b3c2R4-R27)
* Minor cleanup in the navigation menu component to remove an unnecessary space after children.